### PR TITLE
Improve compatibility and structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+cmake-build-debug
+build
+out

--- a/1053/1053_seminar01.c
+++ b/1053/1053_seminar01.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include< malloc.h>
+#include <malloc.h>
 
 void interschimbareNumereIntregi(int* a, int* b)
 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.12)
+set(CMAKE_BUILD_TYPE Debug)
+
+project(SDD2022)
+
+file(GLOB files_srcs CONFIGURE_DEPENDS "*/*.c")
+
+foreach(file IN LISTS files_srcs)
+    get_filename_component(fname "${file}" NAME_WE)
+    add_executable("${fname}" "${file}")
+endforeach()


### PR DESCRIPTION
Added a CMake build script. This will allow opening the repo as a project and running the sources in any CMake-compatible IDE (VS, VSCode, Clion, and others). Each `${group}/${filename}.c` will generate a compile target named `${filename}` automatically, as sources will be added in the future.

A `.gitignore` files was also included to prevent output artifacts (generated by CMake or the IDE) from being accidentally added to the repository