### PR TITLE
Input reading consistency

### DIFF
--- a/1053/1053_seminar02.c
+++ b/1053/1053_seminar02.c
@@ -25,18 +25,15 @@ void citireVectorFisier(FILE* streamFisier, int* nrElem, int** vector)
 
 struct Student citireStudentFisier(FILE* streamFisier) {
 	struct Student student;
-	if (streamFisier != NULL)
-	{
-		char buffer[20];
-		fgets(buffer, 20, streamFisier);
-		char* sir = strtok(buffer, "\n");
-		student.nume = (char*)malloc(sizeof(char) * (strlen(sir) + 1));
-		strcpy(student.nume, sir);
-		fgets(buffer, 4, streamFisier);
-		student.varsta = atoi(buffer);
-		fgets(buffer, 10, streamFisier);
-		student.medie = atof(buffer);
-	}
+    if (streamFisier != NULL)
+    {
+        char buffer[20];
+        fscanf(streamFisier, "%19s", buffer);
+        student.nume = (char*)malloc(sizeof(char) * (strlen(buffer) + 1));
+        strcpy(student.nume, buffer);
+        fscanf(streamFisier, "%d", &student.varsta);
+        fscanf(streamFisier, "%f", &student.medie);
+    }
 	return student;
 }
 

--- a/1053/1053_seminar03.c
+++ b/1053/1053_seminar03.c
@@ -15,14 +15,11 @@ struct Student citireStudent(FILE* streamFisier) {
 	if (streamFisier != NULL)
 	{
 		char buffer[20];
-		fgets(buffer, 20, streamFisier);
-		char* sir = strtok(buffer, "\n");
-		student.nume = (char*)malloc(sizeof(char) * (strlen(sir) + 1));
-		strcpy(student.nume, sir);
-		fgets(buffer, 4, streamFisier);
-		student.varsta = atoi(buffer);
-		fgets(buffer, 10, streamFisier);
-		student.medie = atof(buffer);
+		fscanf(streamFisier, "%19s", buffer);
+		student.nume = (char*)malloc(sizeof(char) * (strlen(buffer) + 1));
+		strcpy(student.nume, buffer);
+        fscanf(streamFisier, "%d", &student.varsta);
+        fscanf(streamFisier, "%f", &student.medie);
 	}
 	return student;
 }
@@ -30,9 +27,7 @@ struct Student citireStudent(FILE* streamFisier) {
 struct Student* citireVectorStudenti(FILE* streamFisier, int* nrStudenti) {
 	if (streamFisier != NULL)
 	{
-		char buffer[10];
-		fgets(buffer, 3, streamFisier);
-		*nrStudenti = atoi(buffer);
+        fscanf(streamFisier, "%d", nrStudenti);
 		struct Student* vectorStudenti = (struct Student*)malloc(sizeof(struct Student) * (*nrStudenti));
 		for (int i = 0; i < (*nrStudenti); i++)
 			vectorStudenti[i] = citireStudent(streamFisier);
@@ -43,9 +38,7 @@ struct Student* citireVectorStudenti(FILE* streamFisier, int* nrStudenti) {
 
 struct Student** citireMatriceStudenti(char* numeFisier, int* nrLinii, int** vectorNrStudentiPeLinie) {
 	FILE* streamFisier = fopen(numeFisier, "r");
-	char buffer[10];
-	fgets(buffer, 10, streamFisier);
-	*nrLinii = atoi(buffer);
+    fscanf(streamFisier, "%d", nrLinii);
 	*vectorNrStudentiPeLinie = (int*)malloc(sizeof(int) * (*nrLinii));
 	struct Student** matriceStudenti = (struct Student**)malloc(sizeof(struct Student*) * (*nrLinii));
 	for (int i = 0; i < (*nrLinii); i++)
@@ -57,17 +50,8 @@ struct Student** citireMatriceStudenti(char* numeFisier, int* nrLinii, int** vec
 
 
 struct Student citireStudentTastatura() {
-	struct Student student;
 	printf("Citire student: ");
-	char buffer[20];
-
-	scanf("%s", &buffer);
-	student.nume = (char*)malloc(sizeof(char) * (strlen(buffer) + 1));
-	strcpy(student.nume, buffer);
-	scanf("%d", &student.varsta);
-	scanf("%f", &student.medie);
-
-	return student;
+    return citireStudent(stdin);
 }
 
 void afisareStudent(struct Student student)

--- a/1056/1056_seminar02.c
+++ b/1056/1056_seminar02.c
@@ -14,16 +14,11 @@ struct Masina citireMasinaFisier(FILE* streamFisier) {
 	if (streamFisier != NULL) {
 		struct Masina masina;
 		char aux[30];
-		fgets(aux, 30, streamFisier);
-		char* sir = strtok(aux, "\n");
-		masina.marca = (char*)malloc(sizeof(char) * (strlen(sir) + 1));
-		strcpy(masina.marca, sir);
-
-		fgets(aux, 10, streamFisier);
-		masina.nrkm = atoi(aux);
-
-		fgets(aux, 10, streamFisier);
-		masina.consum = atof(aux);
+        fscanf(streamFisier, "%29s", aux);
+		masina.marca = (char*)malloc(sizeof(char) * (strlen(aux) + 1));
+		strcpy(masina.marca, aux);
+		fscanf(streamFisier, "%d", &masina.nrkm);
+		fscanf(streamFisier, "%f", &masina.consum);
 
 		return masina;
 	}
@@ -31,9 +26,7 @@ struct Masina citireMasinaFisier(FILE* streamFisier) {
 
 struct Masina* citireMasiniFisier(FILE* streamFisier, int* nrMasini) {
 	if (streamFisier != NULL) {
-		char aux[30];
-		fgets(aux, 3, streamFisier);
-		(*nrMasini) = atoi(aux);
+		fscanf(streamFisier, "%d", nrMasini);
 		struct Masina* vectorMasini = (struct Masina*)malloc((*nrMasini) * sizeof(struct Masina));
 		for (int i = 0; i < (*nrMasini); i++) {
 			vectorMasini[i] = citireMasinaFisier(streamFisier);

--- a/1056/1056_seminar03.c
+++ b/1056/1056_seminar03.c
@@ -11,31 +11,24 @@ struct Masina
 	float consum;
 };
 
-struct Masina citireMasinaFisier(FILE* streamFisier)
-{
-	if (streamFisier != NULL)
-	{
-		struct Masina masina;
-		char aux[30];
-		fgets(aux, 30, streamFisier);
-		char* sir = strtok(aux, "\n");
-		masina.marca = (char*)malloc((strlen(sir) + 1) * sizeof(char));
-		strcpy(masina.marca, sir);
-		fgets(aux, 10, streamFisier);
-		masina.nrKm = atoi(aux);
-		fgets(aux, 10, streamFisier);
-		masina.consum = atof(aux);
+struct Masina citireMasinaFisier(FILE* streamFisier) {
+    if (streamFisier != NULL) {
+        struct Masina masina;
+        char aux[30];
+        fscanf(streamFisier, "%29s", aux);
+        masina.marca = (char*)malloc(sizeof(char) * (strlen(aux) + 1));
+        strcpy(masina.marca, aux);
+        fscanf(streamFisier, "%d", &masina.nrKm);
+        fscanf(streamFisier, "%f", &masina.consum);
 
-		return masina;
-	}
+        return masina;
+    }
 }
 struct Masina* citireMasiniFisier(FILE* streamFisier, int* nrMasini)
 {
 	if (streamFisier != NULL)
 	{
-		char aux[30];
-		fgets(aux, 3, streamFisier);
-		*nrMasini = atoi(aux);
+        fscanf(streamFisier, "%d", nrMasini);
 		struct Masina* vectorMasini = (struct Masina*)malloc(sizeof(struct Masina) * (*nrMasini));
 		for (int i = 0; i < *nrMasini; i++)
 		{
@@ -51,9 +44,7 @@ struct Masina** citireMatriceMasiniFisier(char* numeFisier, int* nrLinii, int** 
 	FILE* streamFisier = fopen(numeFisier, "r");
 	if (streamFisier != NULL)
 	{
-		char aux[30];
-		fgets(aux, 5, streamFisier);
-		*nrLinii = atoi(aux);
+        fscanf(streamFisier, "%d", nrLinii);
 		struct Masina** matriceMasini = (struct Masina**)malloc(sizeof(struct Masina*) * (*nrLinii));
 		*vectorNrMasiniPeLinie = (int*)malloc(sizeof(int) * (*nrLinii));
 		for (int i = 0; i < *nrLinii; i++)
@@ -70,9 +61,7 @@ void citireMatriceMasiniFisier2(struct Masina*** matriceMasini, char* numeFisier
 	FILE* streamFisier = fopen(numeFisier, "r");
 	if (streamFisier != NULL)
 	{
-		char aux[30];
-		fgets(aux, 5, streamFisier);
-		*nrLinii = atoi(aux);
+        fscanf(streamFisier, "%d", nrLinii);
 		(*matriceMasini) = (struct Masina**)malloc(sizeof(struct Masina*) * (*nrLinii));
 		*vectorNrMasiniPeLinie = (int*)malloc(sizeof(int) * (*nrLinii));
 		for (int i = 0; i < *nrLinii; i++)
@@ -101,12 +90,8 @@ void afisareMatriceMasini(struct Masina** matriceMasini, int nrLinii, int* vecto
 
 void citireMasinaTastatura(struct Masina* masina)
 {
-	char aux[50];
-	scanf("%s", aux);
-	(*masina).marca = (char*)malloc(sizeof(char) * (strlen(aux) + 1));
-	strcpy((*masina).marca, aux);
-	scanf("%i", &((*masina).nrKm));
-	scanf("%f", &((*masina).consum));
+    printf("Citire masina: ");
+    *masina = citireMasinaFisier(stdin);
 }
 
 void dezalocareMatriceMasini(struct Masina*** matriceMasini, int* nrLinii, int** vectorNrMasiniPeLinie)


### PR DESCRIPTION
Changed file reading code to use more consistent and safer techniques (reading using `fgets` and then using `atoi`/`atof` can lead to errors - it is not resilient to newline absence). `fscanf` already has all the features needed to read primitive and strings from text files. 

Changed reading from keyboard to use the `stdin` file descriptor, as reading from the keyboard is, from a developer's perspective, identical to reading a file, except when manipulating the terminal emulator with escape codes (not the case here, and not on Windows).